### PR TITLE
Title Fix

### DIFF
--- a/lib/spark.py
+++ b/lib/spark.py
@@ -13,7 +13,7 @@ class SparkIndex(prototypes.Index):
         page = urllib.urlopen(url)
         page_source = page.readlines()
 
-        self.title = "Invisible Man"
+        self.title = self.get_title(page_source)
         self.author = self.get_author(page_source)
         self.sections = self.get_sections(page_source)
         [self.dirname, self.dirname_no_slash] = self.make_dirnames(url)
@@ -46,7 +46,7 @@ class SparkIndex(prototypes.Index):
                 return author
 
     def get_title(self, page_source):
-        regTitle = re.compile('<div.*?\"titleLeft\"><h2>(.*?)<\/')
+        regTitle = re.compile('<div.*?\"titleLeft\"><h[0-9]>(.*?)<\/')
         for line in page_source:
             m = regTitle.search(line)
             if m:

--- a/spark2kindle.py
+++ b/spark2kindle.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import os
 import shutil


### PR DESCRIPTION
Fixed:
    The title was hard-coded and the regex didn't work on a title I tried, so I generalized the title regex and took out the hard code
    Added #!/usr/bin/env python so that it would execute on Linux with python instead of the current shell

Great job by the way.  This is awesome.

Also, are you from reddit, or is this unrelated to http://www.reddit.com/r/kindle/comments/g7l2h/sparknotes_for_kindle/ ?
